### PR TITLE
Refactor: use common RestClient to make rest calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <repository.name>hygieia-feature-jira-collector</repository.name>
     <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
     <bc.version>3.0.1</bc.version>
-    <com.capitalone.dashboard.core.version>3.1.7</com.capitalone.dashboard.core.version>
+    <com.capitalone.dashboard.core.version>3.1.9</com.capitalone.dashboard.core.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang.version>3.8.1</commons.lang.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <repository.name>hygieia-feature-jira-collector</repository.name>
     <apache.rat.plugin.version>0.13</apache.rat.plugin.version>
     <bc.version>3.0.1</bc.version>
-    <com.capitalone.dashboard.core.version>3.1.5</com.capitalone.dashboard.core.version>
+    <com.capitalone.dashboard.core.version>3.1.7</com.capitalone.dashboard.core.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang.version>3.8.1</commons.lang.version>
     <coveralls.maven.plugin.version>4.3.0</coveralls.maven.plugin.version>

--- a/src/main/java/com/capitalone/dashboard/collector/DefaultJiraClient.java
+++ b/src/main/java/com/capitalone/dashboard/collector/DefaultJiraClient.java
@@ -1,5 +1,6 @@
 package com.capitalone.dashboard.collector;
 
+import com.capitalone.dashboard.client.RestClient;
 import com.capitalone.dashboard.misc.HygieiaException;
 import com.capitalone.dashboard.model.Epic;
 import com.capitalone.dashboard.model.Feature;
@@ -77,14 +78,14 @@ public class DefaultJiraClient implements JiraClient {
     private static final String EPIC_ISSUE_TYPE = "Epic";
     private static final int JIRA_BOARDS_PAGING = 50;
     private final FeatureSettings featureSettings;
-    private final RestOperations restOperations;
+    private final RestClient restClient;
     private String issueFields;
     private static JSONParser parser = new JSONParser();
 
     @Autowired
-    public DefaultJiraClient(FeatureSettings featureSettings, Supplier<RestOperations> restOperationsSupplier) {
+    public DefaultJiraClient(FeatureSettings featureSettings, RestClient restClient) {
         this.featureSettings = featureSettings;
-        this.restOperations = restOperationsSupplier.get();
+        this.restClient = restClient;
         issueFields = STATIC_ISSUE_FIELDS + ','
                 + featureSettings.getJiraTeamFieldName() + ','
                 + featureSettings.getJiraSprintDataFieldName() + ','
@@ -821,14 +822,14 @@ public class DefaultJiraClient implements JiraClient {
     private ResponseEntity<String> makeRestCall(String url) throws HygieiaException {
         String jiraAccess = featureSettings.getJiraCredentials();
         if (StringUtils.isEmpty(jiraAccess)) {
-            return restOperations.exchange(url, HttpMethod.GET, null, String.class);
+            return restClient.makeRestCallGet(url);
         } else {
             String jiraAccessBase64 = new String(Base64.decodeBase64(jiraAccess));
             String[] parts = jiraAccessBase64.split(":");
             if (parts.length != 2) {
                 throw new HygieiaException("Invalid Jira credentials", HygieiaException.INVALID_CONFIGURATION);
             }
-            return restOperations.exchange(url, HttpMethod.GET, new HttpEntity<>(createHeaders(parts[0], parts[1])), String.class);
+            return restClient.makeRestCallGet(url, createHeaders(parts[0], parts[1]));
         }
     }
 

--- a/src/test/java/com/capitalone/dashboard/collector/DefaultJiraClientTest.java
+++ b/src/test/java/com/capitalone/dashboard/collector/DefaultJiraClientTest.java
@@ -1,5 +1,6 @@
 package com.capitalone.dashboard.collector;
 
+import com.capitalone.dashboard.client.RestClient;
 import com.capitalone.dashboard.config.FongoConfig;
 import com.capitalone.dashboard.config.TestConfig;
 import com.capitalone.dashboard.model.FeatureEpicResult;
@@ -59,7 +60,8 @@ public class DefaultJiraClientTest {
     public void loadStuff() {
         when(restOperationsSupplier.get()).thenReturn(rest);
 
-        defaultJiraClient = new DefaultJiraClient(featureSettings,restOperationsSupplier);
+        defaultJiraClient = new DefaultJiraClient(featureSettings,new RestClient(restOperationsSupplier)
+        );
     }
 
     @Test
@@ -67,7 +69,7 @@ public class DefaultJiraClientTest {
         doReturn(new ResponseEntity<>(getExpectedJSON("response/issuetype.json"), HttpStatus.OK)).when(rest).exchange(contains("rest/api/2/issuetype"), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class));
         Map<String,String> issueTypeIds = defaultJiraClient.getJiraIssueTypeIds();
         featureSettings.setJiraIssueTypeNames(new String[]{"Story"});
-        defaultJiraClient = new DefaultJiraClient(featureSettings,restOperationsSupplier);
+        defaultJiraClient = new DefaultJiraClient(featureSettings,new RestClient(restOperationsSupplier));
         assertEquals(issueTypeIds.containsKey("Epic"), true);
     }
     @Test
@@ -87,7 +89,7 @@ public class DefaultJiraClientTest {
     public void getProjectsWithAuth() throws IOException{
         doReturn(new ResponseEntity<>(getExpectedJSON("response/projectresponse.json"), HttpStatus.OK)).when(rest).exchange(contains("api/2/project"), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class));
         featureSettings.setJiraCredentials("dXNlcm5hbWU6cGFzc3dvcmQ=");
-        defaultJiraClient = new DefaultJiraClient(featureSettings,restOperationsSupplier);
+        defaultJiraClient = new DefaultJiraClient(featureSettings,new RestClient(restOperationsSupplier));
         Set<Scope> projects = defaultJiraClient.getProjects();
         assertThat(projects.stream().count()).isEqualTo(2);
     }

--- a/src/test/java/com/capitalone/dashboard/collector/FeatureCollectorTaskTest.java
+++ b/src/test/java/com/capitalone/dashboard/collector/FeatureCollectorTaskTest.java
@@ -1,5 +1,6 @@
 package com.capitalone.dashboard.collector;
 
+import com.capitalone.dashboard.client.RestClient;
 import com.capitalone.dashboard.common.TestUtils;
 import com.capitalone.dashboard.config.FongoConfig;
 import com.capitalone.dashboard.config.TestConfig;
@@ -94,7 +95,8 @@ public class FeatureCollectorTaskTest {
         TestUtils.loadScope(projectRepository);
         TestUtils.loadFeature(featureRepository);
         when(restOperationsSupplier.get()).thenReturn(rest);
-        defaultJiraClient = new DefaultJiraClient(featureSettings,restOperationsSupplier);
+        RestClient restClient = new RestClient(restOperationsSupplier);
+        defaultJiraClient = new DefaultJiraClient(featureSettings,restClient);
         featureSettings.setJiraBoardAsTeam(true);
         featureSettings.setCollectorItemOnlyUpdate(false);
         featureCollectorTask = new FeatureCollectorTask(null,featureRepository,teamRepository,projectRepository,featureCollectorRepository,featureSettings,defaultJiraClient, featureBoardRepository);

--- a/src/test/java/com/capitalone/dashboard/config/TestConfig.java
+++ b/src/test/java/com/capitalone/dashboard/config/TestConfig.java
@@ -14,7 +14,7 @@ import org.springframework.scheduling.TaskScheduler;
  */
 @Order(1)
 @Configuration
-@ComponentScan(basePackages ={ "com.capitalone.dashboard.model","com.capitalone.dashboard.collector"}, includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value=com.capitalone.dashboard.collector.FeatureSettings.class))
+@ComponentScan(basePackages ={ "com.capitalone.dashboard.model","com.capitalone.dashboard.collector","com.capitalone.dashboard.client"}, includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value=com.capitalone.dashboard.collector.FeatureSettings.class))
 public class TestConfig {
 
     @Bean


### PR DESCRIPTION
Refactor: use common RestClient to make rest calls, so that log lines and error handlings are standardized